### PR TITLE
feat(ui): add support for calling special backend route

### DIFF
--- a/gateway-vertx/src/main/java/com/redhat/cloudnative/gateway/GatewayVerticle.java
+++ b/gateway-vertx/src/main/java/com/redhat/cloudnative/gateway/GatewayVerticle.java
@@ -34,7 +34,7 @@ public class GatewayVerticle extends AbstractVerticle {
     @Override
     public void start() {
         Router router = Router.router(vertx);
-        router.route().handler(CorsHandler.create("*").allowedMethod(HttpMethod.GET));
+        router.route().handler(CorsHandler.create("*").allowedMethod(HttpMethod.GET).allowedHeader("Ike-Session-Id"));
         router.get("/*").handler(StaticHandler.create("assets"));
         router.get("/health").handler(this::health);
         router.get("/api/products").handler(HeadersHandler::capture).handler(this::products);

--- a/web-nodejs/app/services/catalog.js
+++ b/web-nodejs/app/services/catalog.js
@@ -12,13 +12,18 @@ angular.module("app")
 	}
 
 	factory.getProducts = function() {
-		var deferred = $q.defer();
+        var deferred = $q.defer();
         if (products) {
             deferred.resolve(products);
         } else {
+            var route = $location.search().route
+
             $http({
                 method: 'GET',
-								url: baseUrl
+                url: baseUrl,
+                headers: {
+                    'Ike-Session-Id': route,
+                }
             }).then(function(resp) {
                 products = resp.data;
                 deferred.resolve(resp.data);


### PR DESCRIPTION
Adding ?route=header-value to the URL will append the correct
HTTP Header used by the backend for special development routing.