### PR TITLE
fix: removes leading indentation in the snippet

### DIFF
--- a/bookbag/workshop/content/perform-trace-analysis.adoc
+++ b/bookbag/workshop/content/perform-trace-analysis.adoc
@@ -156,13 +156,13 @@ First we have to fix the problem. **Replace the content of the** `**getAll()**` 
 [source,java]
 .CatalogController.java
 ----
-    @ResponseBody
-    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    public List<Product> getAll() {
-        System.out.println(">>>> getAll, but faster");
-        Spliterator<Product> products = repository.findAll().spliterator();
-        return StreamSupport.stream(products, false).collect(Collectors.toList());
-    }
+@ResponseBody
+@GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+public List<Product> getAll() {
+    System.out.println(">>>> getAll, but faster");
+    Spliterator<Product> products = repository.findAll().spliterator();
+    return StreamSupport.stream(products, false).collect(Collectors.toList());
+}
 ----
 image::images/catalog-controller-updated.png[Catalog Controller Updated- Java code, 700]
 


### PR DESCRIPTION
I don't have a problem with compilation errors in mvn/che anymore, but there was still an issue with selecting the text to copy. Turned out indentation was messing it up.

This PR fixes that.